### PR TITLE
Some improvements to Ceph dashboard

### DIFF
--- a/monasca/control_plane/ceph_aio.json
+++ b/monasca/control_plane/ceph_aio.json
@@ -1,31 +1,5 @@
 {
     "dashboard": {
-        "__requires": [
-            {
-                "id": "singlestat",
-                "name": "Singlestat",
-                "type": "panel",
-                "version": ""
-            },
-            {
-                "id": "graph",
-                "name": "Graph",
-                "type": "panel",
-                "version": ""
-            },
-            {
-                "id": "grafana",
-                "name": "Grafana",
-                "type": "grafana",
-                "version": "4.1.0-pre1"
-            },
-            {
-                "id": "monasca-datasource",
-                "name": "Monasca",
-                "type": "datasource",
-                "version": "1.0.0"
-            }
-        ],
         "annotations": {
             "list": []
         },
@@ -681,7 +655,7 @@
                                 "refId": "A"
                             }
                         ],
-                        "thresholds": "1,2,3",
+                        "thresholds": "1,3",
                         "title": "Object Storage Daemons Down",
                         "type": "singlestat",
                         "valueFontSize": "80%",
@@ -760,7 +734,7 @@
                                 "refId": "A"
                             }
                         ],
-                        "thresholds": "1,2,3",
+                        "thresholds": "1,3",
                         "title": "Object Storage Daemons Out",
                         "type": "singlestat",
                         "valueFontSize": "80%",
@@ -783,7 +757,7 @@
             },
             {
                 "collapse": false,
-                "height": "125",
+                "height": 147,
                 "panels": [
                     {
                         "cacheTimeout": null,
@@ -931,7 +905,7 @@
                             }
                         ],
                         "thresholds": "",
-                        "title": "Average Placement Groups per OSD",
+                        "title": "Avg Placement Groups per OSD",
                         "type": "singlestat",
                         "valueFontSize": "80%",
                         "valueMaps": [
@@ -1071,7 +1045,7 @@
                                 "to": "null"
                             }
                         ],
-                        "span": 2,
+                        "span": 3,
                         "sparkline": {
                             "fillColor": "rgba(31, 118, 189, 0.18)",
                             "full": false,
@@ -1150,7 +1124,7 @@
                                 "to": "null"
                             }
                         ],
-                        "span": 2,
+                        "span": 3,
                         "sparkline": {
                             "fillColor": "rgba(31, 118, 189, 0.18)",
                             "full": false,
@@ -1223,7 +1197,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "aggregator": "avg",
+                                "aggregator": "none",
                                 "alias": "@pool",
                                 "dimensions": [
                                     {
@@ -1233,7 +1207,7 @@
                                 ],
                                 "error": "",
                                 "group": false,
-                                "metric": "ceph.pool.write_bytes",
+                                "metric": "ceph.pool.write_bytes_per_sec",
                                 "period": "300",
                                 "refId": "B"
                             }
@@ -1241,7 +1215,7 @@
                         "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Total Write Throughput",
+                        "title": "Write Bandwidth by Pool",
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
@@ -1305,7 +1279,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "aggregator": "avg",
+                                "aggregator": "none",
                                 "alias": "@pool",
                                 "dimensions": [
                                     {
@@ -1315,7 +1289,7 @@
                                 ],
                                 "error": "",
                                 "group": false,
-                                "metric": "ceph.pool.read_bytes",
+                                "metric": "ceph.pool.read_bytes_per_sec",
                                 "period": "300",
                                 "refId": "A"
                             }
@@ -1323,7 +1297,7 @@
                         "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Total Read Throughput",
+                        "title": "Read Bandwidth by Pool",
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
@@ -1387,7 +1361,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "aggregator": "avg",
+                                "aggregator": "none",
                                 "alias": "@pool",
                                 "dimensions": [
                                     {
@@ -1397,7 +1371,7 @@
                                 ],
                                 "error": "",
                                 "group": false,
-                                "metric": "ceph.pool.write_io",
+                                "metric": "ceph.pool.write_io_per_sec",
                                 "period": "300",
                                 "refId": "B"
                             }
@@ -1405,7 +1379,7 @@
                         "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Total Write I/O Calls",
+                        "title": "Write IOPS by Pool",
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
@@ -1469,7 +1443,7 @@
                         "steppedLine": false,
                         "targets": [
                             {
-                                "aggregator": "avg",
+                                "aggregator": "none",
                                 "alias": "@pool",
                                 "dimensions": [
                                     {
@@ -1479,7 +1453,7 @@
                                 ],
                                 "error": "",
                                 "group": false,
-                                "metric": "ceph.pool.read_io",
+                                "metric": "ceph.pool.read_io_per_sec",
                                 "period": "300",
                                 "refId": "A"
                             }
@@ -1487,7 +1461,7 @@
                         "thresholds": [],
                         "timeFrom": null,
                         "timeShift": null,
-                        "title": "Total Read I/O calls",
+                        "title": "Read IOPS by Pool",
                         "tooltip": {
                             "msResolution": false,
                             "shared": true,
@@ -1552,10 +1526,10 @@
                         "targets": [
                             {
                                 "aggregator": "avg",
-                                "alias": "@pool",
+                                "alias": "@hostname",
                                 "dimensions": [
                                     {
-                                        "key": "pool",
+                                        "key": "hostname",
                                         "value": "$all"
                                     }
                                 ],
@@ -2077,7 +2051,7 @@
         },
         "timezone": "browser",
         "title": "Ceph",
-        "version": 0
+        "version": 14
     },
     "meta": {
         "canEdit": true,
@@ -2088,8 +2062,8 @@
         "expires": "0001-01-01T00:00:00Z",
         "slug": "ceph",
         "type": "db",
-        "updated": "2017-12-19T12:00:27Z",
-        "updatedBy": "admin",
-        "version": 0
+        "updated": "2019-04-10T14:31:15+01:00",
+        "updatedBy": "stig",
+        "version": 14
     }
 }


### PR DESCRIPTION
IO rate metrics by pool, aggregated across all sources.
OSDs down/out intervals - only two needed instead of 3.