### PR TITLE
Display mem.usable_mb for Available Memory graph

### DIFF
--- a/monasca/control_plane/system_overview.json
+++ b/monasca/control_plane/system_overview.json
@@ -321,7 +321,7 @@
                                     }
                                 ],
                                 "error": "",
-                                "metric": "mem.free_mb",
+                                "metric": "mem.usable_mb",
                                 "period": "300",
                                 "refId": "A"
                             }

--- a/monasca/tenant/system_overview.json
+++ b/monasca/tenant/system_overview.json
@@ -320,7 +320,7 @@
                                     }
                                 ],
                                 "error": "",
-                                "metric": "mem.free_mb",
+                                "metric": "mem.usable_mb",
                                 "period": "30",
                                 "refId": "A"
                             }


### PR DESCRIPTION
The mem.usable_mb metric includes both free memory and memory used as cache, which is usable when needed.